### PR TITLE
Enable link opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,3 @@ Once the extensions have been installed, the `SFDX: Create Project` command can 
 The list of currently connected orgs can be viewed using the terminal command `dx-list`. In order to connect to a dev hub, the command `SFDX: Authorize a Dev Hub` can be used from the command bar.
 
 In order to connect to a sandbox, from the terminal, use the `sfdx org login device` command and follow the prompts to set up the sandbox connection.
-
-## Opening a SF org using dx-open
-
-One drawback of using the dev container is that you cannot directly open orgs in the browser using `sfdx org open` (or `dx-open`). Instead, you will get a warning that you are in a headless environment, and there will be a link to the org at the end of the message. You should be able to ctrl/cmd + click the link to open in your default browser.

--- a/devcontainer/devcontainer.json
+++ b/devcontainer/devcontainer.json
@@ -22,5 +22,12 @@
 				"eamodio.gitlens"
 			]
 		}
+	},
+
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			// So vscode can open links in the browser
+			"packages": "xdg-utils"
+		}
 	}
 }


### PR DESCRIPTION
I've found that installing `xdg-utils` is the missing piece to get vscode to be able to open links in devcontainers.

One of the things it installs is `open`. Tested that it triggers the browser to open:

```
open https://nasa.gov
```

![Screenshot from 2024-02-16 18-54-41](https://github.com/e-gineering/sfdx-vscode/assets/7545665/aeed9c72-01e2-47b1-a18e-906c0450ec46)

I've used that for other cli tools in the past that try to open the browser nicely, but I haven't tried it with `sfdx` personally. I assume it's using the same method to open things.

And I'm using that `apt-packages` feature instead of `apt install xdg-utils` just because it's pre-built and a little easier to consume.